### PR TITLE
add freeze & param desc in train.py

### DIFF
--- a/src/training/solution/train.py
+++ b/src/training/solution/train.py
@@ -13,6 +13,10 @@ import os
 ## training dataset                                                                                                  ##
 ##		  - PATH_TO_EXPORTED_MODEL (default value is '/workspace/attendee/') is to specify the path where export the   ##
 ## trained model                                                                                                     ##
+##        - BATCH specifies the number of images used for one training iteration before updating the model's weights.  ##
+## A larger batch size can lead to faster training but requires more memory.
+##        - FREEZE allows to freeze certain layers of a pre-trained model. This way, these layers are kept unchanged   ##
+## during training, which allows to preserve knowledge from the pre-trained model.                                   ##
 #######################################################################################################################
 
 # ✅ Check configuration
@@ -26,8 +30,8 @@ nbOfEpochs = os.getenv('NB_OF_EPOCHS', 50)
 deviceToUse = os.getenv('DEVICE_TO_USE', 0)
 pathToDataset = os.getenv('PATH_TO_DATASET', '/workspace/attendee/data.yaml')
 pathToExportedModel = os.getenv('PATH_TO_EXPORTED_MODEL', '/workspace/attendee/')
-batch = os.getenv('BATCH', 16)
-freeze = os.getenv('FREEZE', None)
+batch = os.getenv('BATCH', 64)
+freeze = os.getenv('FREEZE', 10)
 print('Number of epochs to set:', nbOfEpochs)
 print('Device to set:', deviceToUse)
 print('Path to the dataset to set:', pathToDataset)

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -13,6 +13,10 @@ import os
 ## training dataset                                                                                                  ##
 ##		  - PATH_TO_EXPORTED_MODEL (default value is '/workspace/attendee/') is to specify the path where export the   ##
 ## trained model                                                                                                     ##
+##        - BATCH specifies the number of images used for one training iteration before updating the model's weights.  ##
+## A larger batch size can lead to faster training but requires more memory.
+##        - FREEZE allows to freeze certain layers of a pre-trained model. This way, these layers are kept unchanged   ##
+## during training, which allows to preserve knowledge from the pre-trained model.                                   ##
 #######################################################################################################################
 
 # ✅ Check configuration


### PR DESCRIPTION
i have added Freeze to the default training parameters env variables. 
It is by default affected to 10 frozen layers.
Batch size is also set to 64 by default now to speed up training.

I have also detailed some parameters in the code comments

