### PR TITLE
create and activate a python venv during setup

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -25,3 +25,7 @@ echo "Your notebook URL: " $(jq -r '.notebookUrl' "attendee-conf.json")
 # List the notebook for attendee
 echo ovhai notebook list --token $AI_TOKEN
 ovhai notebook list --token $AI_TOKEN
+
+# create and activate a python venv
+python3 -m venv .venv
+source .venv/bin/activate


### PR DESCRIPTION
when the user source the setup with the command source ./setup_env.sh it creates a venv for Python and activate it.